### PR TITLE
Use explicit reference uris

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "fork-ts-checker-webpack-plugin": "^6.2.5",
         "jest": "^26.6.3",
         "npm-run-all": "^4.1.5",
+        "openapi-typescript": "^6.7.4",
         "prettier": "^2.5.1",
         "serve": "^14.1.2",
         "style-loader": "^3.3.1",
@@ -4287,6 +4288,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -8502,9 +8512,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -14025,9 +14035,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.9.tgz",
-      "integrity": "sha512-MBwILhhD92sziIrMQwpqcuGERF+BH99ei2a3XsGJuqEKcSycAL+w0HWokFenZXona+kjFr82Lf71eTxNRC06XQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "devOptional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -21120,6 +21130,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.4.tgz",
+      "integrity": "sha512-EZyeW9Wy7UDCKv0iYmKrq2pVZtquXiD/YHiUClAKqiMi42nodx/EQH11K6fLqjt1IZlJmVokrAsExsBMM2RROQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.3.2",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.4.0",
+        "undici": "^5.28.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/openapi-typescript/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -26745,6 +26811,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -31682,6 +31760,12 @@
         }
       }
     },
+    "@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "dev": true
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -35154,9 +35238,9 @@
       }
     },
     "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
     "ansi-escapes": {
@@ -39404,9 +39488,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.9.tgz",
-      "integrity": "sha512-MBwILhhD92sziIrMQwpqcuGERF+BH99ei2a3XsGJuqEKcSycAL+w0HWokFenZXona+kjFr82Lf71eTxNRC06XQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "devOptional": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -44940,6 +45024,49 @@
         "is-wsl": "^2.2.0"
       }
     },
+    "openapi-typescript": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.4.tgz",
+      "integrity": "sha512-EZyeW9Wy7UDCKv0iYmKrq2pVZtquXiD/YHiUClAKqiMi42nodx/EQH11K6fLqjt1IZlJmVokrAsExsBMM2RROQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.3.2",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.4.0",
+        "undici": "^5.28.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -49282,6 +49409,15 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "dev": true,
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "fork-ts-checker-webpack-plugin": "^6.2.5",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
+    "openapi-typescript": "^6.7.4",
     "prettier": "^2.5.1",
     "serve": "^14.1.2",
     "style-loader": "^3.3.1",

--- a/src/autogram-api/lib/autogram-api.generated.ts
+++ b/src/autogram-api/lib/autogram-api.generated.ts
@@ -11,29 +11,29 @@ export interface paths {
   };
   "/sign": {
     /**
-     * Sign a single document or single document in batch 
+     * Sign a single document or single document in batch
      * @description Sign a single document or single document in batch.
-     * 
+     *
      * If the `batchId` is provided, the document is signed inside the batch.
-     * 
+     *
      * If the `batchId` is not provided, the document is signed as a standalone document.
      */
     post: operations["signDocument"];
   };
   "/batch": {
     /**
-     * Start a batch session 
+     * Start a batch session
      * @description Start a batch session, `batchId` is returned.
-     * 
+     *
      * Batch session is used to sign multiple documents with the same signature.
      * The batch session is identified and authorized by the `batchId`, keep it secret.
-     * 
+     *
      * After getting the `batchId`, you can sign documents in batch by adding `batchId` property to `POST /sign` [sign](#/{Batch}/{signDocument}) request body.
      * When you are done signing documents, you can end the batch session using `DELETE /batch`.
      */
     post: operations["startBatch"];
     /**
-     * End a batch session 
+     * End a batch session
      * @description End a batch session, either prematurely or after all documents have been signed. Returns status of batch session - if number of signed documents is equal to total number of documents in batch, the status is `FINISHED`, otherwise `NOT_FINISHED`.
      */
     delete: operations["endBatch"];
@@ -55,7 +55,7 @@ export interface components {
        * @description Optional identifier of the batch.
        * If not provided, document will be signed as single standalone document.
        * If provided, document will be signed inside batch.
-       *  
+       *
        * @example 0c62536c-f43f-4302-b8f0-e2ad521c8175
        */
       batchId?: string;
@@ -65,57 +65,57 @@ export interface components {
        * @description MIME type for document content and signature parameters like transformation and schema.
        * Binary files should be encoded using base64, e.g., `application/pdf;base64`.
        * Text formats like XML can be optionally encoded using base64 but can be supplied as plain text as seen in the examples, in which case the type is `application/xml`.
-       *  
+       *
        * @example application/xml
        */
       payloadMimeType: string;
     };
     Document: {
       /**
-       * @description Filename of the original file to be signed. Is used to name the file inside ASiC container. If not provided with ASiC container, the file is named `detached-file` inside the container. 
+       * @description Filename of the original file to be signed. Is used to name the file inside ASiC container. If not provided with ASiC container, the file is named `detached-file` inside the container.
        * @example document.xml
        */
       filename?: string;
       /**
-       * @description Content of the document to sign, format is dictated by `payloadMimeType`. 
+       * @description Content of the document to sign, format is dictated by `payloadMimeType`.
        * @example <?xml version="1.0"?><Document><Title>Lorem Ipsum</Title></Document>
        */
       content: string;
     };
     SignResponseBody: {
       /**
-       * @description Signed content of the original document in Base64 format. 
+       * @description Signed content of the original document in Base64 format.
        * @example TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvQDSdd57FueSBoYW5kcyBtYWtlIGxpZ2h0IHdvsRWdaAeSBoYW5kcyBtYW==
        */
       content: string;
       /**
-       * @description Distinguished name of the certificate used/attempting to sign the document. 
+       * @description Distinguished name of the certificate used/attempting to sign the document.
        * @example SERIALNUMBER=PNOSK-1234567890, C=SK, L=Bratislava, SURNAME=Smith, GIVENNAME=John, CN=John Smith
        */
       signedBy: string;
       /**
-       * @description Distinguished name of the issuer of the certificate used/attempting to sign the document. 
+       * @description Distinguished name of the issuer of the certificate used/attempting to sign the document.
        * @example CN=SVK eID ACA2, O=Disig a.s., OID.2.5.4.97=NTRSK-12345678, L=Bratislava, C=SK
        */
       issuedBy: string;
     };
     BatchStartRequestBody: {
       /**
-       * @description Total number of documents in the batch. Used to calculate the progress of the batch. 
+       * @description Total number of documents in the batch. Used to calculate the progress of the batch.
        * @example 500
        */
       totalNumberOfDocuments?: number;
     };
     BatchStartResponseBody: {
       /**
-       * @description Identifier of the batch. Used to identify the batch for signing and ending batch. 
+       * @description Identifier of the batch. Used to identify the batch for signing and ending batch.
        * @example 0c62536c-f43f-4302-b8f0-e2ad521c8175
        */
       batchId?: string;
     };
     BatchEndRequestBody: {
       /**
-       * @description Identifier of the batch. 
+       * @description Identifier of the batch.
        * @example 0c62536c-f43f-4302-b8f0-e2ad521c8175
        */
       batchId?: string;
@@ -126,112 +126,112 @@ export interface components {
     };
     SignatureParameters: {
       /**
-       * @description Check for PDF/A compliance and show warning if not compliant. 
+       * @description Check for PDF/A compliance and show warning if not compliant.
        * @default false
        */
       checkPDFACompliance?: boolean;
       /**
-       * @description Try to find XSD and XSLT for a given eForm and load them automatically. Useful for visualizing and signing eForms. If true, schema, transformation, conatinerXmlns, container, packaging, and identifier parameters are ignored. If resources are not found, the response is 422. If provided document is an ASiC_E container conatining XML Datacontainer or it is an XML Datacontainer itself, XSLT found is used for visualiztion of signing document. Also, XSD and XSLT hashes are compared with hashes of XSD and XSLT found in XML Data Container EForm. If they differ, the response is 422. If the provided document is an XML document, Autogram will try to parse xmlns from root element and find resources based on its value. If successful, XML Datacontainer with xmls="http://data.gov.sk/def/container/xmldatacontainer+xml/1.1" is created, the document is validated against the XSD and visualized using the XSLT. If XSD validation fails, the response is 422. The XSLT transformation is found based on transformationLanguage (defaults to user preferred), transformationMediaDestinationTypeDescription (default XHTML, then HTML, then TXT), and transformationTargetEnvironment. If multiple transformations meet the criteria, the first one found is used. 
+       * @description Try to find XSD and XSLT for a given eForm and load them automatically. Useful for visualizing and signing eForms. If true, schema, transformation, conatinerXmlns, container, packaging, and identifier parameters are ignored. If resources are not found, the response is 422. If provided document is an ASiC_E container conatining XML Datacontainer or it is an XML Datacontainer itself, XSLT found is used for visualiztion of signing document. Also, XSD and XSLT hashes are compared with hashes of XSD and XSLT found in XML Data Container EForm. If they differ, the response is 422. If the provided document is an XML document, Autogram will try to parse xmlns from root element and find resources based on its value. If successful, XML Datacontainer with xmls="http://data.gov.sk/def/container/xmldatacontainer+xml/1.1" is created, the document is validated against the XSD and visualized using the XSLT. If XSD validation fails, the response is 422. The XSLT transformation is found based on transformationLanguage (defaults to user preferred), transformationMediaDestinationTypeDescription (default XHTML, then HTML, then TXT), and transformationTargetEnvironment. If multiple transformations meet the criteria, the first one found is used.
        * @default false
        */
       autoLoadEform?: boolean;
       /**
-       * @description Signature format PAdES is usable only with documents of type `application/pdf`. Format XAdES is usable with XML or with any file type if using an ASiC container. 
-       * @example XAdES_BASELINE_B 
+       * @description Signature format PAdES is usable only with documents of type `application/pdf`. Format XAdES is usable with XML or with any file type if using an ASiC container.
+       * @example XAdES_BASELINE_B
        * @enum {string}
        */
       level: "XAdES_BASELINE_B" | "PAdES_BASELINE_B" | "CAdES_BASELINE_B";
       /**
-       * @description Optional container type that should be used to place the file with signature to. Defaults to null. Is ignored with autoLoadEform true. 
-       * @example ASiC_E 
+       * @description Optional container type that should be used to place the file with signature to. Defaults to null. Is ignored with autoLoadEform true.
+       * @example ASiC_E
        * @enum {string}
        */
       container?: "ASiC_E";
       /**
-       * @description XML namespace for the XML Datacontainer. Specifies if xmldatacontainer should be created from XML. Doesn't create xmldatacontainer if payloadMimeType is application/vnd.gov.sk.xmldatacontainer+xml already. Accepts http://data.gov.sk/def/container/xmldatacontainer+xml/1.1 only. Defaults to null. Is ignored with autoLoadEform true. 
-       * @example http://data.gov.sk/def/container/xmldatacontainer+xml/1.1 
+       * @description XML namespace for the XML Datacontainer. Specifies if xmldatacontainer should be created from XML. Doesn't create xmldatacontainer if payloadMimeType is application/vnd.gov.sk.xmldatacontainer+xml already. Accepts http://data.gov.sk/def/container/xmldatacontainer+xml/1.1 only. Defaults to null. Is ignored with autoLoadEform true.
+       * @example http://data.gov.sk/def/container/xmldatacontainer+xml/1.1
        * @enum {string}
        */
       containerXmlns?: "http://data.gov.sk/def/container/xmldatacontainer+xml/1.1";
       /**
-       * @description Optional identifier of the document template. Required if containerXmlns is http://data.gov.sk/def/container/xmldatacontainer+xml/1.1. Defaults to null. Is ignored with autoLoadEform true. 
+       * @description Optional identifier of the document template. Required if containerXmlns is http://data.gov.sk/def/container/xmldatacontainer+xml/1.1. Defaults to null. Is ignored with autoLoadEform true.
        * @example https://data.gov.sk/id/egov/eform/App.GeneralAgenda/1.9
        */
       identifier?: string;
       /**
-       * @description Optional form of packaging used with XML. ENVELOPED adds the signature as a child of the root element while ENVELOPING wraps the XML in a new element. Only applies to XAdES signatures. Must be ENVELOPING when used without ASiC container and with non XML documents. Is ignored with autoLoadEform true. 
-       * @default ENVELOPED 
+       * @description Optional form of packaging used with XML. ENVELOPED adds the signature as a child of the root element while ENVELOPING wraps the XML in a new element. Only applies to XAdES signatures. Must be ENVELOPING when used without ASiC container and with non XML documents. Is ignored with autoLoadEform true.
+       * @default ENVELOPED
        * @enum {string}
        */
       packaging?: "ENVELOPED" | "ENVELOPING";
       /**
-       * @description Optional algorithm used to calculate digests. 
-       * @default SHA256 
+       * @description Optional algorithm used to calculate digests.
+       * @default SHA256
        * @enum {string}
        */
       digestAlgorithm?: "SHA256" | "SHA384" | "SHA512";
       /**
-       * @description Optional flag to control whether the signature should be made according to ETSI EN 319132 for XAdES and ETSI EN 319122 for CAdES and PAdES. 
+       * @description Optional flag to control whether the signature should be made according to ETSI EN 319132 for XAdES and ETSI EN 319122 for CAdES and PAdES.
        * @default false
        */
       en319132?: boolean;
       /**
-       * @description Optional info canonicalization method. 
-       * @default INCLUSIVE 
+       * @description Optional info canonicalization method.
+       * @default INCLUSIVE
        * @enum {string}
        */
       infoCanonicalization?: "INCLUSIVE" | "EXCLUSIVE" | "INCLUSIVE_WITH_COMMENTS" | "EXCLUSIVE_WITH_COMMENTS" | "INCLUSIVE_11" | "INCLUSIVE_11_WITH_COMMENTS";
       /**
-       * @description Optional properties canonicalization method. 
-       * @default INCLUSIVE 
+       * @description Optional properties canonicalization method.
+       * @default INCLUSIVE
        * @enum {string}
        */
       propertiesCanonicalization?: "INCLUSIVE" | "EXCLUSIVE" | "INCLUSIVE_WITH_COMMENTS" | "EXCLUSIVE_WITH_COMMENTS" | "INCLUSIVE_11" | "INCLUSIVE_11_WITH_COMMENTS";
       /**
-       * @description Optional key info canonicalization method. 
-       * @default INCLUSIVE 
+       * @description Optional key info canonicalization method.
+       * @default INCLUSIVE
        * @enum {string}
        */
       keyInfoCanonicalization?: "INCLUSIVE" | "EXCLUSIVE" | "INCLUSIVE_WITH_COMMENTS" | "EXCLUSIVE_WITH_COMMENTS" | "INCLUSIVE_11" | "INCLUSIVE_11_WITH_COMMENTS";
       /**
-       * @description Optional XML schema used to validate the signing document and to compute digest used in "UsedXSDReference" in "DigestValue" attribute inside created XML Datacontainer. Format (plaintext or base64) is dictated by `payloadMimeType`. Is ignored with autoLoadEform true. 
+       * @description Optional XML schema used to validate the signing document and to compute digest used in "UsedXSDReference" in "DigestValue" attribute inside created XML Datacontainer. Format (plaintext or base64) is dictated by `payloadMimeType`. Is ignored with autoLoadEform true.
        * @example <?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:element name="Document"><xs:complexType><xs:sequence><xs:element name="Title" type="xs:string" /></xs:sequence></xs:complexType></xs:element></xs:schema>
        */
       schema?: string;
       /**
-       * @description Optional identifier of the XML schema. The value is used in "UsedXSDReference" field inside created XML Datacontainer. If provided with autoLoadEform true, Autogram will try to find such schema. Default value is "http://schemas.gov.sk/form/<form-idnetifier>/<version>/form.xsd". 
+       * @description Optional identifier of the XML schema. The value is used in "UsedXSDReference" field inside created XML Datacontainer. If provided with autoLoadEform true, Autogram will try to find such schema. Default value is "http://schemas.gov.sk/form/<form-idnetifier>/<version>/form.xsd".
        * @example http://schemas.gov.sk/form/App.GeneralAgenda/1.9/form.xsd
        */
       schemaIdentifier?: string;
       /**
-       * @description Optional XML transformation used to present the signing document to user and to compute digest used in "UsedPresentationSchemaReference" in "DigestValue" attribute inside created XML Datacontainer. Format (plaintext or base64) is dictated by `payloadMimeType`. Is ignored with autoLoadEform true. 
+       * @description Optional XML transformation used to present the signing document to user and to compute digest used in "UsedPresentationSchemaReference" in "DigestValue" attribute inside created XML Datacontainer. Format (plaintext or base64) is dictated by `payloadMimeType`. Is ignored with autoLoadEform true.
        * @example <?xml version="1.0"?><xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:template match = "/"><h1><xsl:value-of select="/Document/Title"/></h1></xsl:template></xsl:stylesheet>
        */
       transformation?: string;
       /**
-       * @description Optional identifier of the XML transformation. If provided with autoLoadEform true, Autogram will try to find such transformation. Default value is "http://schemas.gov.sk/form/<form-idnetifier>/<version>/form.xslt". 
+       * @description Optional identifier of the XML transformation. If provided with autoLoadEform true, Autogram will try to find such transformation. Default value is "http://schemas.gov.sk/form/<form-idnetifier>/<version>/form.xslt".
        * @example http://schemas.gov.sk/form/App.GeneralAgenda/1.9/form.xslt
        */
       transformationIdentifier?: string;
       /**
-       * @description Optional language of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this language. Otherwise transformation must be provided. Default value is user preferred or "sk". 
+       * @description Optional language of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this language. Otherwise transformation must be provided. Default value is user preferred or "sk".
        * @example sk
        */
       transformationLanguage?: string;
       /**
-       * @description Optional media destination type description of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this type. Otherwise transformation must be provided. Overrides value of the output method in provided or auto-loaded transformation which is used by default. 
-       * @example HTML 
+       * @description Optional media destination type description of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this type. Otherwise transformation must be provided. Overrides value of the output method in provided or auto-loaded transformation which is used by default.
+       * @example HTML
        * @enum {string}
        */
-      transformationMediaDestinationTypeDescription?: "XHTML" | "HTML" | "TXT";
+      transformationMediaDestinationTypeDescription?: string;
       /**
-       * @description Optional target environment of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this target. Otherwise transformation must be provided. Null and not used by default. 
+       * @description Optional target environment of the XML transformation. If autoLoadEform is true, Autogram will try to find signing XSLT with this target. Otherwise transformation must be provided. Null and not used by default.
        * @example example-value
        */
       transformationTargetEnvironment?: string;
       /**
-       * @description Optional width of the signing document visualization. Values are sm (640px), md (768px), lg (1024px), xl (1280px), xxl (1536px). The minimum visualization width is set to 640px. If the preferred visualization width is exceeds width of client's screen, the visualization width is set to the width of the client's screen. 
-       * @default sm 
+       * @description Optional width of the signing document visualization. Values are sm (640px), md (768px), lg (1024px), xl (1280px), xxl (1536px). The minimum visualization width is set to 640px. If the preferred visualization width is exceeds width of client's screen, the visualization width is set to the width of the client's screen.
+       * @default sm
        * @enum {string}
        */
       visualizationWidth?: "sm" | "md" | "lg" | "xl" | "xxl";
@@ -260,11 +260,11 @@ export interface operations {
     };
   };
   /**
-   * Sign a single document or single document in batch 
+   * Sign a single document or single document in batch
    * @description Sign a single document or single document in batch.
-   * 
+   *
    * If the `batchId` is provided, the document is signed inside the batch.
-   * 
+   *
    * If the `batchId` is not provided, the document is signed as a standalone document.
    */
   signDocument: {
@@ -287,18 +287,18 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @description Code that can be used to identify the error. 
-             * @example MALFORMED_INPUT 
+             * @description Code that can be used to identify the error.
+             * @example MALFORMED_INPUT
              * @enum {string}
              */
             code?: "BATCH_CONFLICT" | "BATCH_ENDED" | "BATCH_EXPIRED" | "BATCH_NOT_STARTED" | "EMPTY_BODY" | "MALFORMED_INPUT" | "MULTIPLE_ORIGINAL_DOCUMENTS" | "ORIGINAL_DOCUMENT_NOT_FOUND";
             /**
-             * @description Human readable error message. 
+             * @description Human readable error message.
              * @example JsonSyntaxException parsing request body.
              */
             message?: string;
             /**
-             * @description Optional details. 
+             * @description Optional details.
              * @example JsonSyntaxException: Unexpected token END OF FILE at position 0.
              */
             details?: string;
@@ -310,18 +310,18 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @description Code that can be used to identify the error. 
-             * @example BATCH_NOT_FOUND 
+             * @description Code that can be used to identify the error.
+             * @example BATCH_NOT_FOUND
              * @enum {string}
              */
             code?: "BATCH_NOT_FOUND";
             /**
-             * @description Human readable error message. 
+             * @description Human readable error message.
              * @example Invalid BatchId provided
              */
             message?: string;
             /**
-             * @description More detailed human readable error message. 
+             * @description More detailed human readable error message.
              * @example Batch signing attempt failed. Batch with the given `batchId` was not found or the batch session has ended.
              */
             details?: string;
@@ -333,18 +333,18 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @description Code that can be used to identify the error. 
-             * @example UNPROCESSABLE_INPUT 
+             * @description Code that can be used to identify the error.
+             * @example UNPROCESSABLE_INPUT
              * @enum {string}
              */
             code?: "UNPROCESSABLE_INPUT" | "UNSUPPORTED_SIGNATURE_LEVEL";
             /**
-             * @description Human readable error message. 
+             * @description Human readable error message.
              * @example IllegalArgumentException parsing request body
              */
             message?: string;
             /**
-             * @description Optional details. 
+             * @description Optional details.
              * @example PayloadMimeType must be PDF when using PAdES.
              */
             details?: string;
@@ -356,17 +356,17 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @example INTERNAL_ERROR 
+             * @example INTERNAL_ERROR
              * @enum {string}
              */
             code?: "INTERNAL_ERROR";
             /**
-             * @description Human readable error message. 
+             * @description Human readable error message.
              * @example Unexpected exception signing document
              */
             message?: string;
             /**
-             * @description Optional details. 
+             * @description Optional details.
              * @example java.lang.NullPointerException: null
              */
             details?: string;
@@ -378,18 +378,18 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @description Code that can be used to identify the error. 
-             * @example UNRECOGNIZED_DSS_ERROR 
+             * @description Code that can be used to identify the error.
+             * @example UNRECOGNIZED_DSS_ERROR
              * @enum {string}
              */
             code?: "UNRECOGNIZED_DSS_ERROR" | "SIGNING_FAILED";
             /**
-             * @description Human readable error message. 
+             * @description Human readable error message.
              * @example Unable to sign document
              */
             message?: string;
             /**
-             * @description Optional details. 
+             * @description Optional details.
              * @example no such algorithm: PKCS11 for provider
              */
             details?: string;
@@ -399,12 +399,12 @@ export interface operations {
     };
   };
   /**
-   * Start a batch session 
+   * Start a batch session
    * @description Start a batch session, `batchId` is returned.
-   * 
+   *
    * Batch session is used to sign multiple documents with the same signature.
    * The batch session is identified and authorized by the `batchId`, keep it secret.
-   * 
+   *
    * After getting the `batchId`, you can sign documents in batch by adding `batchId` property to `POST /sign` [sign](#/{Batch}/{signDocument}) request body.
    * When you are done signing documents, you can end the batch session using `DELETE /batch`.
    */
@@ -424,7 +424,7 @@ export interface operations {
     };
   };
   /**
-   * End a batch session 
+   * End a batch session
    * @description End a batch session, either prematurely or after all documents have been signed. Returns status of batch session - if number of signed documents is equal to total number of documents in batch, the status is `FINISHED`, otherwise `NOT_FINISHED`.
    */
   endBatch: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const enabledUrls = [
   "https://schranka.slovensko.sk/*",
   "https://pfseform.financnasprava.sk/*",
   "https://www.financnasprava.sk/*",
+  "https://cep.financnasprava.sk/*",
+  "https://www.cep.financnasprava.sk/*",
   "https://eformulare.socpoist.sk/*",
   ...(process.env.NODE_ENV !== "production" ? ["http://localhost:3000/*"] : []),
 ];

--- a/src/dbridge_js/ditecx/filetype-strategy/base-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/base-strategy.ts
@@ -7,6 +7,11 @@ export interface ObjectStrategy {
   objTransformation: string;
   identifier: SignatureParameters["identifier"];
   formVersion: string;
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
   /**
    * Type of payload for Autogram (Autogram input)
    */
@@ -30,8 +35,22 @@ class EmptyStrategy implements ObjectStrategy {
   get objectId() {
     return null;
   }
-
   get identifier() {
+    return null;
+  }
+  get schemaIdentifier() {
+    return null;
+  }
+  get transformationIdentifier() {
+    return null;
+  }
+  get transformationMediaDestinationTypeDescription() {
+    return null;
+  }
+  get transformationLanguage() {
+    return null;
+  }
+  get transformationTargetEnvironment() {
     return null;
   }
   get payloadMimeType(): PayloadMimeTypeStr {

--- a/src/dbridge_js/ditecx/filetype-strategy/pdf-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/pdf-strategy.ts
@@ -4,12 +4,18 @@ import {
 } from "./base-strategy";
 import { AutogramDocument } from "../../../client";
 import { ObjectXadesPdf } from "../types";
+import { SignatureParameters } from "../../../autogram-api";
 
 export class XadesPdfStrategy implements ObjectStrategy {
   obj: ObjectXadesPdf;
   constructor(object: ObjectXadesPdf) {
     this.obj = object;
   }
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
 
   get document(): AutogramDocument {
     return { content: this.obj.sourcePdfBase64, filename: this.obj.objectId };

--- a/src/dbridge_js/ditecx/filetype-strategy/png-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/png-strategy.ts
@@ -4,12 +4,18 @@ import {
 } from "./base-strategy";
 import { AutogramDocument } from "../../../client";
 import { ObjectXadesBpPng } from "../types";
+import { SignatureParameters } from "../../../autogram-api";
 
 export class XadesBpPngStrategy implements ObjectStrategy {
   obj: ObjectXadesBpPng;
   constructor(object: ObjectXadesBpPng) {
     this.obj = object;
   }
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
 
   get document(): AutogramDocument {
     return {

--- a/src/dbridge_js/ditecx/filetype-strategy/txt-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/txt-strategy.ts
@@ -6,12 +6,18 @@ import {
 import { ObjectXadesBpTxt } from "../types";
 import { Base64 } from "js-base64";
 import { AutogramDocument } from "../../../client";
+import { SignatureParameters } from "../../../autogram-api";
 
 export class XadesBpTxtStrategy implements ObjectStrategy {
   obj: ObjectXadesBpTxt;
   constructor(object: ObjectXadesBpTxt) {
     this.obj = object;
   }
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
 
   get document(): AutogramDocument {
     return {

--- a/src/dbridge_js/ditecx/filetype-strategy/xml-bp-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/xml-bp-strategy.ts
@@ -5,6 +5,7 @@ import {
 import { AutogramDocument } from "../../../client";
 import { ObjectXadesBp2Xml, ObjectXadesBpXml } from "../types";
 import { Base64 } from "js-base64";
+import { SignatureParameters } from "../../../autogram-api";
 
 export class XadesBpXmlStrategy implements ObjectStrategy {
   obj: ObjectXadesBpXml;
@@ -33,6 +34,21 @@ export class XadesBpXmlStrategy implements ObjectStrategy {
   get identifier() {
     return this.obj.xdcIdentifier;
   }
+  get schemaIdentifier() {
+    return this.obj.xsdReferenceURI;
+  }
+  get transformationIdentifier() {
+    return this.obj.xslReferenceURI;
+  }
+  get transformationMediaDestinationTypeDescription() {
+    return this.obj.xslMediaDestinationTypeDescription;
+  }
+  get transformationLanguage() {
+    return this.obj.xslXSLTLanguage;
+  }
+  get transformationTargetEnvironment() {
+    return this.obj.xslTargetEnvironment;
+  }
   get payloadMimeType(): PayloadMimeTypeStr {
     return "application/xml";
   }
@@ -43,6 +59,11 @@ export class XadesBp2XmlStrategy implements ObjectStrategy {
   constructor(object: ObjectXadesBp2Xml) {
     this.obj = object;
   }
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
 
   isXmlDataContainer() {
     return true;

--- a/src/dbridge_js/ditecx/filetype-strategy/xml-strategy.ts
+++ b/src/dbridge_js/ditecx/filetype-strategy/xml-strategy.ts
@@ -4,12 +4,18 @@ import {
 } from "./base-strategy";
 import { AutogramDocument } from "../../../client";
 import { ObjectXades2Xml, ObjectXadesXml } from "../types";
+import { SignatureParameters } from "../../../autogram-api";
 
 export class XadesXmlStrategy implements ObjectStrategy {
   obj: ObjectXadesXml | ObjectXades2Xml;
   constructor(object: ObjectXadesXml | ObjectXades2Xml) {
     this.obj = object;
   }
+  schemaIdentifier: string;
+  transformationIdentifier: string;
+  transformationMediaDestinationTypeDescription: SignatureParameters["transformationMediaDestinationTypeDescription"];
+  transformationLanguage: string;
+  transformationTargetEnvironment: string;
 
   get document(): AutogramDocument {
     return {

--- a/src/dbridge_js/ditecx/sign-request.ts
+++ b/src/dbridge_js/ditecx/sign-request.ts
@@ -81,6 +81,11 @@ export class SignRequest {
       transformation: this.objectInfo.objTransformation,
       schema: this.objectInfo.objSchema,
       checkPDFACompliance: true,
+      schemaIdentifier: getNullIfEmpty(this.objectInfo.schemaIdentifier),
+      transformationIdentifier: getNullIfEmpty(this.objectInfo.transformationIdentifier),
+      transformationMediaDestinationTypeDescription: getNullIfEmpty(this.objectInfo.transformationMediaDestinationTypeDescription),
+      transformationLanguage: getNullIfEmpty(this.objectInfo.transformationLanguage),
+      transformationTargetEnvironment: getNullIfEmpty(this.objectInfo.transformationTargetEnvironment),
     };
   }
 
@@ -133,6 +138,10 @@ function getProperty<T>(obj: object, propertyName: string, defaultValue: T) {
   return Object.prototype.hasOwnProperty.call(obj, propertyName)
     ? obj[propertyName]
     : defaultValue;
+}
+
+function getNullIfEmpty(s: string) {
+  return (s != null && s.length > 0) ? s : null;
 }
 
 // function assertUnreachable(x: never): never {

--- a/src/dbridge_js/ditecx/types.ts
+++ b/src/dbridge_js/ditecx/types.ts
@@ -26,7 +26,7 @@ export interface ObjectXadesBpXml {
   xsdReferenceURI;
   xdcUsedXSLT: string;
   xslReferenceURI: string;
-  xslMediaDestinationTypeDescription;
+  xslMediaDestinationTypeDescription: string;
   xslXSLTLanguage: string;
   xslTargetEnvironment: string;
   xdcIncludeRefs: boolean;


### PR DESCRIPTION
Extension doteraz nepoužíval všetky parametre, ktoré portály podpisovaču posielajú. Okrem xsd a xslt uri som teda rovno pridal aj language, mediadestiantiontypeenv a target. Tieto parametre majú svoje opodstatnenie. Konkrétne tento PR inicioval prlbém na FS, kde sa v jednom formulári v Autograme vyrábali iné referencie než bolo treba, pritom protál ich podpisovaču posielal správne, len cez extension sa už ďalej nedostali.